### PR TITLE
Fix parsing issue for optional deps

### DIFF
--- a/library/aura.py
+++ b/library/aura.py
@@ -302,9 +302,17 @@ class Aura(object):
         lines = colourless_info.split('\n')
         info_dict = {}
         for line in lines:
-            if line:
-                key, value = line.split(':', 1)
-                info_dict[key.strip()] = value.strip()
+            if not line:
+                continue
+
+            # continuation of previous key
+            if line.startswith(" "):
+                previous_key = list(info_dict)[-1]
+                info_dict[previous_key] += "\n" + line.strip()
+                continue
+
+            key, value = line.split(':', 1)
+            info_dict[key.strip()] = value.strip()
         return info_dict
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Issue

When running `_extract_info` on a package with optional deps that do not have a description, the module fails:
```
  File \"/tmp/ansible_aura_payload_d710gtr8/ansible_aura_payload.zip/ansible/modules/aura.py\", line 323, in _extract_info
ValueError: not enough values to unpack (expected 2, got 1)
```

<details>
<summary>Example input</summary>

```
Name            : opentabletdriver
Version         : 0.6.4.0-4
Description     : A cross-platform open source tablet driver
Architecture    : x86_64
URL             : https://opentabletdriver.net
Licenses        : LGPL3
Groups          : None
Provides        : None
Depends On      : dotnet-runtime-6.0  gtk3  libevdev
Optional Deps   : libxrandr: x11 display querying support [installed]
                  libx11 [installed]
Required By     : None
Optional For    : None
Conflicts With  : digimend-kernel-drivers-dkms-git  digimend-drivers-git-dkms  digimend-kernel-drivers-dkms  digimend-kernel-drivers
Replaces        : None
Installed Size  : 23.77 MiB
Packager        : Unknown Packager
Build Date      : Wed 01 May 2024 09:51:03 AM CEST
Install Date    : Wed 01 May 2024 09:52:00 AM CEST
Install Reason  : Explicitly installed
Install Script  : Yes
Validated By    : None
```
</details>

This line does not contain a `:`, thus raising an error when splitting:
```
                  libx11 [installed]
```

### Solution

If the line begins with a space, assume it is a continuation of the last key and append it.